### PR TITLE
fix: stabilize dashboard vitest run and invite validation (Refs #42)

### DIFF
--- a/src/controllers/__tests__/useAuthController.test.jsx
+++ b/src/controllers/__tests__/useAuthController.test.jsx
@@ -22,6 +22,7 @@ vi.mock("../../services", () => ({
 
 describe("useAuthController", () => {
   it("surfaces the Google prompt reason when the prompt is not displayed", async () => {
+    vi.stubEnv("VITE_GOOGLE_CLIENT_ID", "test-google-client-id");
     window.google = {
       accounts: {
         id: {
@@ -84,6 +85,7 @@ describe("useAuthController", () => {
     expect(setError).toHaveBeenCalledWith(
       "Google login failed: prompt was not displayed (unregistered_origin)."
     );
+    vi.unstubAllEnvs();
   });
 
   it("submits auth and refreshes session data", async () => {

--- a/src/controllers/useAuthController.js
+++ b/src/controllers/useAuthController.js
@@ -3,9 +3,12 @@ import { clearSession, getAccessToken, saveSession } from "../api";
 import { authService, submitAuth, submitGoogleAuth } from "../services";
 
 const GOOGLE_SCRIPT_ID = "google-identity-services-script";
-const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
 const GOOGLE_TOKEN_MISSING_ERROR = "Google login failed: no ID token was returned. Please try again.";
 let googleScriptPromise = null;
+
+function getGoogleClientId() {
+  return import.meta.env.VITE_GOOGLE_CLIENT_ID;
+}
 
 function toGoogleLoginError(notification) {
   const notDisplayedReason = notification?.getNotDisplayedReason?.();
@@ -72,7 +75,9 @@ export function useAuthController({
 }) {
   const isAuthenticated = Boolean(getAccessToken());
   const [googleButtonNode, setGoogleButtonNode] = useState(null);
-  const [googleButtonStatus, setGoogleButtonStatus] = useState(GOOGLE_CLIENT_ID ? "loading" : "unconfigured");
+  const [googleButtonStatus, setGoogleButtonStatus] = useState(() => (
+    getGoogleClientId() ? "loading" : "unconfigured"
+  ));
 
   useEffect(() => {
     (async () => {
@@ -149,7 +154,8 @@ export function useAuthController({
     const container = googleButtonNode;
     if (!container) return;
 
-    if (!GOOGLE_CLIENT_ID) {
+    const googleClientId = getGoogleClientId();
+    if (!googleClientId) {
       container.innerHTML = "";
       setGoogleButtonStatus("unconfigured");
       return;
@@ -166,7 +172,7 @@ export function useAuthController({
         }
 
         window.google.accounts.id.initialize({
-          client_id: GOOGLE_CLIENT_ID,
+          client_id: googleClientId,
           callback: onGoogleLoginSuccess
         });
 
@@ -203,7 +209,8 @@ export function useAuthController({
     setError("");
     setSuccess("");
 
-    if (!GOOGLE_CLIENT_ID) {
+    const googleClientId = getGoogleClientId();
+    if (!googleClientId) {
       setError("Google login is not configured.");
       return;
     }
@@ -215,7 +222,7 @@ export function useAuthController({
       }
 
       window.google.accounts.id.initialize({
-        client_id: GOOGLE_CLIENT_ID,
+        client_id: googleClientId,
         callback: onGoogleLoginSuccess
       });
 

--- a/src/controllers/useDashboardController.js
+++ b/src/controllers/useDashboardController.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { getAccessToken } from "../api";
 import { isValidGroupName } from "../models";
 import { groupService } from "../services";
@@ -192,6 +192,9 @@ export function useDashboardController({
   const [inviteCandidatesLoading, setInviteCandidatesLoading] = useState(false);
   const [groupOwnershipById, setGroupOwnershipById] = useState({});
   const groupsSignature = groups.map((group) => `${group?.id || ""}:${group?.name || ""}`).join("|");
+  // Keep a stable group reference for effects that only care about id/name changes.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const groupsForEffects = useMemo(() => groups, [groupsSignature]);
 
   useEffect(() => {
     setGroupOwnershipById({});
@@ -203,14 +206,14 @@ export function useDashboardController({
     let cancelled = false;
 
     async function resolveOwnership() {
-      if (!groups.length) {
+      if (!groupsForEffects.length) {
         if (!cancelled && Object.keys(groupOwnershipById).length > 0) {
           setGroupOwnershipById({});
         }
         return;
       }
 
-      const unresolved = groups
+      const unresolved = groupsForEffects
         .map((group) => group?.id)
         .filter((groupId) => groupId && groupOwnershipById[groupId] === undefined);
 
@@ -245,7 +248,7 @@ export function useDashboardController({
         });
 
         Object.keys(next).forEach((groupId) => {
-          if (!groups.some((group) => group.id === groupId)) {
+          if (!groupsForEffects.some((group) => group.id === groupId)) {
             delete next[groupId];
           }
         });
@@ -258,7 +261,7 @@ export function useDashboardController({
     return () => {
       cancelled = true;
     };
-  }, [currentId, groupOwnershipById, groupsSignature, groups, setGroups]);
+  }, [currentId, groupOwnershipById, groupsForEffects, groupsSignature, setGroups]);
 
   const loadPendingInvites = useCallback(async () => {
     if (!getAccessToken() || !currentEmail || currentEmail === "-") {
@@ -339,7 +342,7 @@ export function useDashboardController({
       return;
     }
 
-    if (!groups.length) {
+    if (!groupsForEffects.length) {
       setSentInvites([]);
       return;
     }
@@ -354,13 +357,13 @@ export function useDashboardController({
             .map((invite) => normalizeSentInvite(invite, {
               currentId,
               fallbackGroupId: invite?.groupId || "",
-              fallbackGroupName: invite?.groupName || groups.find((group) => group.id === invite?.groupId)?.name || "Group"
+              fallbackGroupName: invite?.groupName || groupsForEffects.find((group) => group.id === invite?.groupId)?.name || "Group"
             }))
             .filter(Boolean)
         ];
       } else {
         inviteResults = await Promise.all(
-          groups.map(async (group) => {
+          groupsForEffects.map(async (group) => {
             try {
               const invites = await groupService.listGroupInvites(group.id);
               if (!Array.isArray(invites)) return [];
@@ -387,7 +390,7 @@ export function useDashboardController({
     return () => {
       cancelled = true;
     };
-  }, [currentId, groupsSignature, me, groups]);
+  }, [currentId, groupsForEffects, groupsSignature, me]);
 
   async function onCreateGroup(e) {
     e.preventDefault();

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -175,6 +175,10 @@ export function validateUuid(id) {
   return { valid: true, error: null };
 }
 
+export function isUuid(id) {
+  return validateUuid(id).valid;
+}
+
 /**
  * Batch validate multiple fields
  * Returns first error found or null if all valid

--- a/src/views/DashboardView.jsx
+++ b/src/views/DashboardView.jsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { useAlerts } from "../contexts/AlertContext";
 import { useAuth } from "../contexts/AuthContext";
 import { isGroupOwner as checkGroupOwnership } from "../utils/groupOwnership";
-import { isUuid } from "../../utils/validation";
+import { isUuid } from "../utils/validation";
 import DashboardEmptyState from "./components/DashboardEmptyState";
 import DashboardGroupCardItem from "./components/DashboardGroupCardItem";
 import DashboardHero from "./components/DashboardHero";


### PR DESCRIPTION
## Summary
- stabilize dashboard controller effects so sent-invite loading no longer loops and crash Vitest workers
- add the shared isUuid validation helper and fix the dashboard view import path
- keep dashboard tests and invite behavior aligned with the current view/controller wiring

## Verification
- npm run lint
- npm test

Refs #42